### PR TITLE
refactor: use whiskers

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,5 @@
+_default:
+  @just --list
+
+build:
+  whiskers qterminal.tera

--- a/qterminal.tera
+++ b/qterminal.tera
@@ -1,0 +1,108 @@
+---
+whiskers:
+  version: "2.2.0"
+  matrix:
+    - flavor
+  filename: "src/Catppuccin-{{ flavor.identifier | capitalize }}.colorscheme"
+---
+
+{%- macro rgb(color) -%}
+{{ color.rgb.r }},{{ color.rgb.g }},{{ color.rgb.b }}
+{%- endmacro -%}
+
+[Background]
+Color={{ self::rgb(color=base) }}
+
+[BackgroundFaint]
+Color={{ self::rgb(color=base) }}
+
+[BackgroundIntense]
+Color={{ self::rgb(color=base) }}
+
+[Color0]
+Color={{ self::rgb(color=overlay0) }}
+
+[Color0Faint]
+Color={{ self::rgb(color=overlay0) }}
+
+[Color0Intense]
+Color={{ self::rgb(color=overlay0) }}
+
+[Color1]
+Color={{ self::rgb(color=red) }}
+
+[Color1Faint]
+Color={{ self::rgb(color=red) }}
+
+[Color1Intense]
+Color={{ self::rgb(color=red) }}
+
+[Color2]
+Color={{ self::rgb(color=green) }}
+
+[Color2Faint]
+Color={{ self::rgb(color=green) }}
+
+[Color2Intense]
+Color={{ self::rgb(color=green) }}
+
+[Color3]
+Color={{ self::rgb(color=yellow) }}
+
+[Color3Faint]
+Color={{ self::rgb(color=yellow) }}
+
+[Color3Intense]
+Color={{ self::rgb(color=yellow) }}
+
+[Color4]
+Color={{ self::rgb(color=blue) }}
+
+[Color4Faint]
+Color={{ self::rgb(color=blue) }}
+
+[Color4Intense]
+Color={{ self::rgb(color=blue) }}
+
+[Color5]
+Color={{ self::rgb(color=mauve) }}
+
+[Color5Faint]
+Color={{ self::rgb(color=mauve) }}
+
+[Color5Intense]
+Color={{ self::rgb(color=mauve) }}
+
+[Color6]
+Color={{ self::rgb(color=sky) }}
+
+[Color6Faint]
+Color={{ self::rgb(color=sky) }}
+
+[Color6Intense]
+Color={{ self::rgb(color=sky) }}
+
+[Color7]
+Color={{ self::rgb(color=text) }}
+
+[Color7Faint]
+Color={{ self::rgb(color=text) }}
+
+[Color7Intense]
+Color={{ self::rgb(color=text) }}
+
+[Foreground]
+Color={{ self::rgb(color=text) }}
+
+[ForegroundFaint]
+Color={{ self::rgb(color=text) }}
+
+[ForegroundIntense]
+Color={{ self::rgb(color=text) }}
+
+[General]
+Blur=false
+ColorRandomization=false
+Description=Catppuccin {{ flavor.name }}
+Opacity=1
+Wallpaper=

--- a/src/Catppuccin-Macchiato.colorscheme
+++ b/src/Catppuccin-Macchiato.colorscheme
@@ -62,13 +62,13 @@ Color=198,160,246
 Color=198,160,246
 
 [Color6]
-Color=137,220,227
+Color=145,215,227
 
 [Color6Faint]
-Color=137,220,227
+Color=145,215,227
 
 [Color6Intense]
-Color=137,220,227
+Color=145,215,227
 
 [Color7]
 Color=202,211,245


### PR DESCRIPTION
Adds [Whiskers](https://github.com/catppuccin/toolbox/tree/main/whiskers), Catppuccin's internal templating tool, to build the themes. Instead of editing the `.colorscheme` files directly, edit the `qterminal.tera` file and then run `just build` to build the output themes. You will need Whiskers (linked above) and *optionally* [Just](https://github.com/casey/just) installed.